### PR TITLE
correct quote method

### DIFF
--- a/includes/modules/shipping/upsoauth.php
+++ b/includes/modules/shipping/upsoauth.php
@@ -363,7 +363,7 @@ class upsoauth extends base
         $all_ups_quotes = $this->upsApi->getAllUpsQuotes($_SESSION['upsoauth_token']);
         if (empty($all_ups_quotes->RateResponse->RatedShipment)) {
             if (!isset($all_ups_quotes->response->errors)) {
-                return false;
+                return [];
             }
 
             // -----
@@ -427,8 +427,10 @@ class upsoauth extends base
                 $error_message = sprintf(MODULE_SHIPPING_UPSOAUTH_ERROR, $ups_error_code);
             }
             $this->quotes = [
+                'id' => $this->code,
                 'module' => $this->title,
                 'error' => $error_message,
+                'methods' => [],
             ];
             if (!empty($this->icon)) {
                 $this->quotes['icon'] = zen_image($this->icon, $this->title);
@@ -442,13 +444,13 @@ class upsoauth extends base
         //
         $ups_quotes = $this->upsApi->getConfiguredUpsQuotes($all_ups_quotes);
         if ($ups_quotes === false) {
-            return false;
+            return [];
         }
 
         $methods = $this->upsApi->getShippingMethodsFromQuotes($method, $ups_quotes);
         if (count($methods) === 0) {
             $this->debugLog("No available methods matching required '$method'; no UPS quotes available.");
-            return false;
+            return [];
         }
 
         // -----


### PR DESCRIPTION
per the [docs](https://docs.zen-cart.com/dev/code/modules/shipping_modules/#quote), `id` and `methods` are required.  in addition, without the `id` opc will generate errors [here.](https://github.com/lat9/one_page_checkout/blob/460a21ea5a50d8c73fdc8ff97e2308a030740a45/includes/templates/template_default/templates/tpl_modules_checkout_one_shipping.php#L14)

without `methods`, previous versions of bootstrap will generate errors on the shipping estimator.  it seems that the current version of bootstrap does all of these conditional checks to ensure that `methods` are there.  sending an empty array would prevent the need to do all of those jumping through hoops there.

similarly, the quote method should return an array not a boolean. 

if no methods are available, and you do not want to display an error message to the user, an empty array is what should be expected of this method.  this PR replaces those returns of `false` to an empty array.

finally, while i am here, i see no need for all of the lines from 384 to 428.  what is wrong with the message provided by ups?  it just makes it easier to display their error message than to hard code one's own.  i think all of that code can be replaced by:

```php
            $error_message = sprintf(MODULE_SHIPPING_UPSOAUTH_ERROR, $ups_error_code);
            if (!empty($all_ups_quotes->response->errors[0]->message)) {
                $error_message = $all_ups_quotes->response->errors[0]->message;
            }
```
but alas, i doubt you will want to merge that.