### PR TITLE
Clean up deprecated curl_close() calls for PHP 8.0+ compatibility

### DIFF
--- a/includes/modules/shipping/upsoauth/UpsOAuthApi.php
+++ b/includes/modules/shipping/upsoauth/UpsOAuthApi.php
@@ -3,9 +3,9 @@
 // API/Rate-generation interfaces that support shipping modules that use the
 // UPS RESTful API with OAuth authentication.
 //
-// Last updated: v1.3.8
+// Last updated: v1.3.9
 //
-// Copyright 2023-2025, Vinos de Frutas Tropicales
+// Copyright 2023-2026, Vinos de Frutas Tropicales
 //
 if (!defined('IS_ADMIN_FLAG')) {
     die('Illegal Access');

--- a/includes/modules/shipping/upsoauth/UpsOAuthApi.php
+++ b/includes/modules/shipping/upsoauth/UpsOAuthApi.php
@@ -217,7 +217,9 @@ class UpsOAuthApi extends base
             $token = json_decode($response);
          }
 
-        curl_close($ch);
+        if (PHP_VERSION_ID < 80000) {
+            curl_close($ch);
+        }
 
         return $token;
     }
@@ -255,7 +257,9 @@ class UpsOAuthApi extends base
                 $response_details = false;
             }
         }
-        curl_close($ch);
+        if (PHP_VERSION_ID < 80000) {
+            curl_close($ch);
+        }
 
         return $response_details;
     }


### PR DESCRIPTION
Since PHP 8.0, curl_close() doesn't do anything.

Ref #49 

Note: I don't use 'fixes', as an issue remains open until its correction is released.